### PR TITLE
Update to GNOME 41 runtime

### DIFF
--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -91,11 +91,17 @@
                 "/share/gtk-doc"
             ],
             "sources": [
-                 {
-                     "type": "archive",
-                     "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.16.2.tar.xz",
-                     "sha256": "f1cb7aa2389569a5343661aae473f0a940a90b872001824bc47fa8072a041e74"
-                 }
+                {
+                    "type": "archive",
+                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.18.5.tar.xz",
+                    "sha256": "a164923b94f0d08578a6fcaeaac6e0c05da788a46903a1086870e9ca45ad678e",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 21849,
+                        "stable-only": true,
+                        "url-template": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-$version.tar.xz"
+                    }
+                }
             ]
         },
         {

--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -46,6 +46,7 @@
         "--talk-name=org.endlessos.onboarding",
         "--talk-name=org.gnome.Software",
         "--talk-name=com.endlessm.EknServices3.SearchProviderV3",
+        "--talk-name=com.endlessm.EknServices4.SearchProviderV4",
         "--filesystem=xdg-run/dconf",
         "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf",

--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -10,7 +10,7 @@
     },
 
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
 
     "command": "eos-clubhouse",

--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -8,13 +8,10 @@
             "autodelete": true
         }
     },
-
     "runtime": "org.gnome.Platform",
     "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
-
     "command": "eos-clubhouse",
-
     "finish-args": [
         "--env=GNOTIFICATION_BACKEND=gtk",
         "--env=GSETTINGS_SCHEMA_DIR=/run/host/usr/share/glib-2.0/schemas/",
@@ -53,7 +50,6 @@
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--require-version=1.8.2"
     ],
-
     "modules": [
         {
             "name": "clippy-ext",
@@ -108,7 +104,7 @@
         {
             "name": "hack-sound-server",
             "buildsystem": "meson",
-            "config-opts" : [
+            "config-opts": [
                 "-Dsession-bus-services-dir=/app/share/dbus-1/services"
             ],
             "sources": [
@@ -168,7 +164,7 @@
         {
             "name": "game-state-service",
             "buildsystem": "meson",
-            "config-opts" : [
+            "config-opts": [
                 "-Dsession-bus-services-dir=/app/share/dbus-1/services"
             ],
             "sources": [
@@ -215,7 +211,7 @@
             "build-options": {
                 "build-args": []
             },
-            "config-opts" : [
+            "config-opts": [
                 "-Dsession-bus-services-dir=/app/share/dbus-1/services",
                 "-Dmatomo-host=https://endlessos.matomo.cloud",
                 "-Dmatomo-site-id=1",
@@ -224,7 +220,9 @@
             ],
             "run-tests": false,
             "test-rule": "",
-            "test-commands": ["meson test --timeout-multiplier=10 --print-errorlogs"],
+            "test-commands": [
+                "meson test --timeout-multiplier=10 --print-errorlogs"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
It builds, and it runs, but it doesn't work reliably. EG when I try the lightswitch:

```
INFO:eosclubhouse:Running quest "Lightswitch"
Traceback (most recent call last):
  File "/app/lib/python3.9/site-packages/glibcoro.py", line 93, in awaitit
    result = await future
  File "/app/lib/python3.9/site-packages/eosclubhouse/libquest.py", line 535, in wait_or_timeout
  File "/usr/lib/python3.9/asyncio/tasks.py", line 397, in wait
    loop = events.get_running_loop()
RuntimeError: no running event loop
Exception in callback _QuestRunContext.set_next_step.<locals>._run_step((<bound method...f Lightswitch>, ('CHAT1',)))() at /app/lib/python3.9/site-packages/eosclubhouse/libquest.py:428
handle: <Handle _QuestRunContext.set_next_step.<locals>._run_step((<bound method...f Lightswitch>, ('CHAT1',)))() at /app/lib/python3.9/site-packages/eosclubhouse/libquest.py:428>
Traceback (most recent call last):
  File "/usr/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/app/lib/python3.9/site-packages/eosclubhouse/libquest.py", line 436, in _run_step
  File "/app/lib/python3.9/site-packages/eosclubhouse/quests/hack2/lightswitch.py", line 57, in step_button_pressed
UnboundLocalError: local variable 'next_msgid' referenced before assignment
```