### PR TITLE
Update Git URL for Soundtouch

### DIFF
--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -71,7 +71,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.com/soundtouch/soundtouch.git",
+                    "url": "https://codeberg.org/soundtouch/soundtouch.git",
                     "tag": "2.1.2",
                     "commit": "9205fc971ed23cff407a67242bb9036a51113af4"
                 }


### PR DESCRIPTION
The old URL is broken: attempting to access it yields 404, or prompts
for authentication if you are not signed into GitLab.

I found its new home. Here's the note in the README there:

> 2021-10-14 OP: For some reason that currently is unknown to us,
> gitlab.com blocked soundtouch account without any prior notice, hence
> soundtouch repository moved to codeberg.org, hopefully a more stable
> and friendly home for an opensource project.

It is the same code – the commit hash for 2.1.2 matches.

This is the same change as https://github.com/endlessm/clubhouse/pull/1239. Should it target beta, or master? I don't quite follow the branch/merge strategy here.