### PR TITLE
Fix the import of glibcoro and persist-queue packages

### DIFF
--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -188,7 +188,7 @@
                 }
             ],
             "build-commands": [
-                "python3 ./setup.py install --prefix=/app"
+                "python3 ./setup.py install --single-version-externally-managed --root / --prefix=/app"
             ]
         },
         {
@@ -203,7 +203,7 @@
                 }
             ],
             "build-commands": [
-                "python3 ./setup.py install --prefix=/app"
+                "python3 ./setup.py install --single-version-externally-managed --root / --prefix=/app"
             ]
         },
         {

--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -223,8 +223,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/endlessm/clubhouse.git",
-                    "branch": "eos5",
-                    "commit": "986fe0e907b350539400fba1ed771accba5bd8b0"
+                    "commit": "22861758f52fca777ee35689fc3b6650dc144ca2"
                 }
             ]
         }


### PR DESCRIPTION
Python 3.10 cannot import the glibcoro and persist-queue packages correctly. Add the the --single-version-externally-managed option for Python packages to fix this issue.

Fixes: https://github.com/flathub/com.hack_computer.Clubhouse/issues/22