### PR TITLE
Downgrade the runtime to GNOME 42

### DIFF
--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -224,7 +224,7 @@
                     "type": "git",
                     "url": "https://github.com/endlessm/clubhouse.git",
                     "branch": "eos5",
-                    "commit": "986fe0e907b350539400fba1ed771accba5bd8b0"
+                    "commit": "22861758f52fca777ee35689fc3b6650dc144ca2"
                 }
             ]
         }

--- a/com.hack_computer.Clubhouse.json
+++ b/com.hack_computer.Clubhouse.json
@@ -10,7 +10,7 @@
     },
 
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "eos-clubhouse",
     "finish-args": [
@@ -91,8 +91,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.20.4.tar.xz",
-                    "sha256": "a1a3f53b3604d9a04fdd0bf9a1a616c3d2dab5320489e9ecee1178e81e33a16a",
+                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.18.6.tar.xz",
+                    "sha256": "0b1b50ac6311f0c510248b6cd64d6d3c94369344828baa602db85ded5bc70ec9",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 21849,


### PR DESCRIPTION
The Asyncio of clubhouse has compatibility issue with Python 3.10+ [1]. And, GNOME 43 runtime has Python 3.10. However, we has not had a way to fix the issue, yet. Therefore, downgrade the runtime to GNOME 42 to gain more time to fix the Asyncio compatibilty issue between clubhouse and Python 3.10+.

Follow the commit ("Downgrade the runtime to GNOME 42") of upstream clippy [2].

Besides, downgrade gst-plugins-bad to 1.18.6 for GNOME 42 runtime compatiblity, too.

[1]: https://github.com/flathub/com.hack_computer.Clubhouse/issues/22#issuecomment-1352841349
[2]: https://github.com/endlessm/clippy